### PR TITLE
fix: show label on all sh:or/sh:xone property instances

### DIFF
--- a/src/constraints.ts
+++ b/src/constraints.ts
@@ -71,10 +71,21 @@ export function createShaclOrConstraint(options: Term[], context: ShaclNode | Sh
             if (quads.length) {
                 values.push(quads)
                 let label = findLabel(quads, config.languages)
+                if (!label) {
+                    // try sh:name as fallback for label
+                    for (const quad of quads) {
+                        if (quad.predicate.value === `${PREFIX_SHACL}name`) {
+                            label = quad.object.value
+                            break
+                        }
+                    }
+                }
                 // if no label found, but one of the quads has a sh:node predicate, try to find the label for the referenced node shape
-                for (const quad of quads) {
-                    if (quad.predicate.equals(SHACL_PREDICATE_NODE)) {
-                        label = findLabel(config.store.getQuads(quad.object, null, null, null), config.languages)
+                if (!label) {
+                    for (const quad of quads) {
+                        if (quad.predicate.equals(SHACL_PREDICATE_NODE)) {
+                            label = findLabel(config.store.getQuads(quad.object, null, null, null), config.languages)
+                        }
                     }
                 }
                 optionElements.push({ label: label || (removePrefixes(quads[0].predicate.value, prefixes) + ' = ' + removePrefixes(quads[0].object.value, prefixes)), value: i.toString() })


### PR DESCRIPTION
Issue:
When a property has sh:or or sh:xone and the user adds multiple values, only the first instance displays its label. Subsequent instances have their labels hidden.
This is caused by the existing CSS rule in the default theme:
css.property-instance:not(:first-child) > label:not(.persistent) { visibility: hidden; max-height: 0; }
This rule is correct for regular multi-valued properties (e.g., multiple names), where repeating the label is redundant. However, for sh:or/sh:xone, each instance may represent a different option (e.g., "Email address" vs "Phone number"), so the label provides essential context about which option was selected.

To reproduce:
```turtle
@prefix sh:   <http://www.w3.org/ns/shacl#> .
@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
@prefix ex:   <http://example.org/> .

ex:EmailOption
    a sh:PropertyShape ;
    sh:name "Email address" ;
    sh:description "A valid email address" ;
    sh:datatype xsd:string ;
    sh:pattern "^[^@]+@[^@]+$" .

ex:PhoneOption
    a sh:PropertyShape ;
    sh:name "Phone number" ;
    sh:description "A phone number with optional country code" ;
    sh:datatype xsd:string ;
    sh:pattern "^\\+?[0-9\\-\\s]+$" .

ex:ContactShape
    a sh:NodeShape ;
    sh:targetClass ex:Contact ;
    sh:property [
        sh:path ex:contactInfo ;
        sh:name "Contact information" ;
        sh:or ( ex:EmailOption ex:PhoneOption ) ;
    ] .
```

Add a Contact information, select "Email address" → label shows
Add another Contact information, select "Phone number" → label hidden 