### PR TITLE
ensure merging of properties of lazily instantiated node shapes

### DIFF
--- a/src/node-template.ts
+++ b/src/node-template.ts
@@ -54,6 +54,7 @@ export class ShaclNodeTemplate {
     extendedShapes: Set<ShaclNodeTemplate> = new Set()
     properties: Record<string, ShaclPropertyTemplate[]> = {} // sh:path -> sh:property
     owlImports: Set<NamedNode> = new Set()
+    merged = false
     config: Config
 
     constructor(id: Term, config: Config, parent?: ShaclNodeTemplate | ShaclPropertyTemplate) {
@@ -75,6 +76,10 @@ export function mergeQuads(template: ShaclNodeTemplate, quads: Quad[]) {
 
 // merges properties with same sh:path and no sh:qualifiedValueShape on upmost suitable parent if cardinality of merged property's sh:maxCount equals 1
 export function mergeOverriddenProperties(node: ShaclNodeTemplate) {
+    if (node.merged) {
+        return
+    }
+    node.merged = true
     for (const props of Object.values(node.properties)) {
         for (const prop of props) {
             const [chain, maxCountIsOne] = buildPropertyChain(node, prop.path!)

--- a/src/node.ts
+++ b/src/node.ts
@@ -6,7 +6,7 @@ import { createShaclGroup } from './group'
 import { v4 as uuidv4 } from 'uuid'
 import { createShaclOrConstraint, resolveShaclOrConstraintOnNode } from './constraints'
 import { Config } from './config'
-import { ShaclNodeTemplate } from './node-template'
+import { ShaclNodeTemplate, mergeOverriddenProperties } from './node-template'
 import { ShaclPropertyTemplate } from './property-template'
 
 export class ShaclNode extends HTMLElement {
@@ -75,6 +75,8 @@ export class ShaclNode extends HTMLElement {
                 div.classList.add('node-id-display')
                 this.appendChild(div)
             }
+            // ensure overridden properties are merged before render, necessary for lazily referenced shape (e.g. inside sh:xone)
+            mergeOverriddenProperties(template)
             this.ready = (async () => {
                 const childAncestorShapeIds = new Set(ancestorShapeIds)
                 childAncestorShapeIds.add(currentShapeId)


### PR DESCRIPTION
If a node shape is used, for example, with `sh:qualifiedValueShape` inside `sh:or` or `sh:xone`, `mergeOverridenProperties` is not executed, leading to the display of properties both how they are defined in a base profile and how they are defined in a child profile.

[Example](https://ulb-darmstadt.github.io/shacl-form/#try-your-own?QHByZWZpeCBzaDogICA8aHR0cDovL3d3dy53My5vcmcvbnMvc2hhY2wjPiAuCkBwcmVmaXggcmRmOiAgPGh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyM+IC4KQHByZWZpeCByZGZzOiA8aHR0cDovL3d3dy53My5vcmcvMjAwMC8wMS9yZGYtc2NoZW1hIz4gLgpAcHJlZml4IHhzZDogIDxodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hNTFNjaGVtYSM+IC4KQHByZWZpeCBleDogICA8aHR0cDovL2V4YW1wbGUub3JnLz4gLgoKCiMgU2hhcGUgd2l0aCBOb2RlU2hhcGVzIGluc2lkZSBzaDp4b25lCmV4OlhvbmVTaGFwZSAKICBhIHNoOk5vZGVTaGFwZSwgcmRmczpDbGFzcyA7CiAgc2g6cHJvcGVydHkgWwogICAgc2g6bmFtZSAgICAgIkNoaWxkIFNoYXBlcyIgOwogICAgc2g6cGF0aCAgICAgZXg6ZW50cnkgOwogICAgc2g6bm9kZUtpbmQgc2g6QmxhbmtOb2RlT3JJUkkgOwogICAgc2g6bWluQ291bnQgMSA7CiAgICBzaDptYXhDb3VudCAxIDsKICAgIHNoOnhvbmUgKAogICAgICBbCiAgICAgICAgc2g6bmFtZSAiQ2hpbGQgMSIgOwogICAgICAgIHNoOnF1YWxpZmllZFZhbHVlU2hhcGUgZXg6Q2hpbGRTaGFwZSA7CiAgICAgICAgc2g6cXVhbGlmaWVkTWluQ291bnQgMSA7CiAgICAgICAgc2g6cXVhbGlmaWVkTWF4Q291bnQgMSA7CiAgICAgIF0KICAgICAgWyAKICAgICAgICBzaDpuYW1lICJDaGlsZCAyIiA7CiAgICAgICAgc2g6cXVhbGlmaWVkVmFsdWVTaGFwZSBleDpDaGlsZFNoYXBlMiA7CiAgICAgICAgc2g6cXVhbGlmaWVkTWluQ291bnQgMSA7CiAgICAgICAgc2g6cXVhbGlmaWVkTWF4Q291bnQgMSA7CiAgICAgIF0KICAgICkgOwogIF0gLgoKIyB0aGUgdHdvIGNoaWxkIHNoYXBlcyByZWZlcmVuY2VkIGFib3ZlCmV4OkNoaWxkU2hhcGUgCiAgYSBzaDpOb2RlU2hhcGUsIHJkZnM6Q2xhc3MgOwogIHNoOm5vZGUgZXg6QmFzZVNoYXBlIDsKICBzaDpwcm9wZXJ0eSBbCiAgICBzaDpuYW1lICAgICAiY2hpbGQgbGFiZWwiIDsKICAgIHNoOnBhdGggICAgIHJkZnM6bGFiZWwgOwogICAgc2g6aGFzVmFsdWUgIkZpeGVkIGxhYmVsIiA7CiAgXSAuCgpleDpDaGlsZFNoYXBlMiAKICBhIHNoOk5vZGVTaGFwZSwgcmRmczpDbGFzcyA7CiAgc2g6bm9kZSBleDpCYXNlU2hhcGUgOwogIHNoOnByb3BlcnR5IFsKICAgIHNoOm5hbWUgICAgICJjaGlsZCBsYWJlbCAyIiA7CiAgICBzaDpwYXRoICAgICByZGZzOmxhYmVsIDsKICAgIHNoOmhhc1ZhbHVlICJBbm90aGVyIGZpeGVkIGxhYmVsIiA7CiAgXSAuCgojIHRoZSBiYXNlIHNoYXBlIG9mIHRoZSBjaGlsZHJlbiBhYm92ZQpleDpCYXNlU2hhcGUgCiAgYSBzaDpOb2RlU2hhcGUsIHJkZnM6Q2xhc3MgOwogIHNoOnByb3BlcnR5IFsKICAgIHNoOnBhdGggICAgIHJkZnM6bGFiZWwgOwogICAgc2g6bmFtZSAgICAgImxhYmVsIiA7CiAgICBzaDpkYXRhdHlwZSB4c2Q6c3RyaW5nIDsKICAgIHNoOm1pbkNvdW50IDEgOwogICAgc2g6bWF4Q291bnQgMSA7CiAgXSAuCg==)

Explicit call of `mergeOverriddenProperties` in the constructor of ShaclNode should merge properties during rendering in this case. New flag `merged` is introduced to avoid unnecessary execution for node shape that were already merged