### PR TITLE
fix(security): use textContent instead of innerHTML in createButton

### DIFF
--- a/src/plugins/leaflet.ts
+++ b/src/plugins/leaflet.ts
@@ -170,7 +170,7 @@ export class LeafletPlugin extends Plugin {
         if (!dialog) {
             dialog = this.initEditMode(template.config.form)
         }
-        const button = template.config.theme.createButton('Open&#160;map...', false)
+        const button = template.config.theme.createButton('Open map...', false)
         button.style.marginLeft = '5px'
         button.classList.add('open-map-button')
         button.onclick = () => {

--- a/src/theme.default.ts
+++ b/src/theme.default.ts
@@ -307,7 +307,7 @@ export class DefaultTheme extends Theme {
     createButton(label: string, primary: boolean): HTMLElement {
         const button = new RokitButton()
         button.dense = this.dense
-        button.innerHTML = label
+        button.textContent = label
         if (primary) {
             button.setAttribute('primary', '')
             button.setAttribute('part', 'button primary')


### PR DESCRIPTION
`Theme.createButton()` set button content via `innerHTML` instead of `textContent`, while every other label-rendering call site in the codebase used the safe approach. Since button labels can originate from `sh:name` in the SHACL shapes graph (an untrusted source when shapes are loaded from remote URLs), this allowed HTML/script injection.

This PR switches to `textContent`, and updates the one caller (`plugins/leaflet.ts`) that relied on an HTML entity (`&#160;`) for a non-breaking space, replacing it with a plain space.