### PR TITLE
fix(jsonld): compare rdf:type predicate with .equals() instead of ===

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -25,7 +25,7 @@ function serializeJsonld(quads: Quad[]): string {
     for (const quad of quads) {
         const triple: NodeObject = { '@id': quad.subject.id }
 
-        if (quad.predicate === RDF_PREDICATE_TYPE) {
+        if (quad.predicate.equals(RDF_PREDICATE_TYPE)) {
             triple['@type'] = quad.object.id
         } else {
             let object: string | Record<string, string> = quad.object.value


### PR DESCRIPTION
`serializeJsonld()` compared `quad.predicate === RDF_PREDICATE_TYPE` using reference equality instead of `.equals()`, which almost every RDF-term comparison uses. Since N3.js's `DataFactory.namedNode()` creates a new object on every call, this comparison was always false, so `rdf:type` triples never used the compact `@type` JSON-LD keyword. Instead, they fell through to the long-form IRI key.

This PR switches to `.equals()` and make it consistent with the rest of the RDF-term comparison.